### PR TITLE
Add namespace to slash commands to prevent conflicts

### DIFF
--- a/.claude/commands/seomachine/analyze-existing.md
+++ b/.claude/commands/seomachine/analyze-existing.md
@@ -3,7 +3,7 @@
 Use this command to review and analyze existing your company blog posts for SEO opportunities, content gaps, and improvement areas.
 
 ## Usage
-`/analyze-existing [URL or file path]`
+`/seomachine:analyze-existing [URL or file path]`
 
 ## What This Command Does
 1. Fetches and analyzes existing blog post content
@@ -111,8 +111,8 @@ Example: `research/analysis-podcast-hosting-guide-2025-10-15.md`
 
 ## Next Steps
 Based on the analysis, the system will suggest:
-1. Running `/rewrite [topic]` if content needs significant updates
-2. Running `/optimize [file]` if content needs light SEO polish
+1. Running `/seomachine:rewrite [topic]` if content needs significant updates
+2. Running `/seomachine:optimize [file]` if content needs light SEO polish
 3. Archiving the post if it's no longer relevant or valuable
 
 This ensures every analysis leads to clear, actionable next steps for improving your company blog content.

--- a/.claude/commands/seomachine/optimize.md
+++ b/.claude/commands/seomachine/optimize.md
@@ -3,7 +3,7 @@
 Use this command to perform a final SEO optimization pass on completed articles before publishing.
 
 ## Usage
-`/optimize [article file]`
+`/seomachine:optimize [article file]`
 
 ## What This Command Does
 1. Performs comprehensive SEO audit of article
@@ -232,7 +232,7 @@ Visual representation of where primary keyword appears:
 **Next Steps**:
 1. [Specific action needed]
 2. [Specific action needed]
-3. Move to `/published` folder when complete
+3. Move to `published/` folder when complete
 
 ## File Management
 After optimization analysis, save report to:
@@ -243,7 +243,7 @@ After optimization analysis, save report to:
 Example: `drafts/optimization-report-podcast-analytics-2025-10-15.md`
 
 ## Integration with Agents
-The `/optimize` command triggers final review from all agents:
+The `/seomachine:optimize` command triggers final review from all agents:
 - **content-analyzer** (NEW!): Comprehensive analysis with search intent, keyword density & clustering, content length comparison, readability score, and SEO quality rating (0-100)
 - **seo-optimizer**: Technical SEO final check
 - **meta-creator**: Best meta title/description options

--- a/.claude/commands/seomachine/performance-review.md
+++ b/.claude/commands/seomachine/performance-review.md
@@ -3,7 +3,7 @@
 Use this command to analyze content performance data and generate a prioritized queue of content tasks.
 
 ## Usage
-`/performance-review [days]`
+`/seomachine:performance-review [days]`
 
 ## What This Command Does
 1. Fetches data from Google Analytics, Google Search Console, and DataForSEO
@@ -161,14 +161,14 @@ The Performance Agent output directly informs other commands:
 
 1. **Quick Win Identified**: "podcast monetization" at position 13
    ```
-   /analyze-existing /blog/podcast-monetization-guide
-   /optimize drafts/podcast-monetization-guide.md
+   /seomachine:analyze-existing /blog/podcast-monetization-guide
+   /seomachine:optimize drafts/podcast-monetization-guide.md
    ```
 
 2. **Declining Content**: Article lost 35% traffic
    ```
-   /analyze-existing /blog/podcast-equipment-guide
-   /rewrite podcast equipment guide
+   /seomachine:analyze-existing /blog/podcast-equipment-guide
+   /seomachine:rewrite podcast equipment guide
    ```
 
 3. **Low CTR**: High impressions, 2.5% CTR
@@ -179,14 +179,14 @@ The Performance Agent output directly informs other commands:
 
 4. **Trending Topic**: "AI podcast tools" +150% growth
    ```
-   /research AI podcast tools
-   /write AI podcast tools
+   /seomachine:research AI podcast tools
+   /seomachine:write AI podcast tools
    ```
 
 5. **Competitor Gap**: competitor.com ranks #3, your company not ranking
    ```
-   /research podcast editing workflow
-   /write podcast editing workflow
+   /seomachine:research podcast editing workflow
+   /seomachine:write podcast editing workflow
    ```
 
 ## Frequency Recommendations
@@ -197,7 +197,7 @@ The Performance Agent output directly informs other commands:
 - Adjust current work based on new data
 
 **Monthly** (Full Review):
-- Complete `/performance-review` analysis
+- Complete `/seomachine:performance-review` analysis
 - Assess previous month's actions and results
 - Plan next month's content priorities
 - Adjust strategy based on trends
@@ -267,22 +267,22 @@ Plan reviews accounting for data lag.
 
 ### Custom Analysis Period
 ```
-/performance-review 90  # Last 90 days for long-term trends
-/performance-review 7   # Last 7 days for recent changes
+/seomachine:performance-review 90  # Last 90 days for long-term trends
+/seomachine:performance-review 7   # Last 7 days for recent changes
 ```
 
 ### Focus on Specific Content
 After full review, drill into specific pages:
 ```
 # From performance review, identify problem page
-/analyze-existing /blog/specific-article
-/rewrite specific article
+/seomachine:analyze-existing /blog/specific-article
+/seomachine:rewrite specific article
 ```
 
 ### Compare Periods
 ```
 # Run monthly to track changes
-/performance-review 30   # This month
+/seomachine:performance-review 30   # This month
 # Compare to previous report from 30 days ago
 ```
 
@@ -324,28 +324,28 @@ A successful performance review should:
 
 ```bash
 # Month start: Run performance review
-/performance-review 30
+/seomachine:performance-review 30
 
 # Review report: research/performance-review-2025-10-15.md
 # Identify top 5 priorities
 
 # Week 1: Quick wins
-/analyze-existing /blog/top-quick-win-article
-/optimize drafts/top-quick-win-article.md
+/seomachine:analyze-existing /blog/top-quick-win-article
+/seomachine:optimize drafts/top-quick-win-article.md
 
 # Week 2: Declining content
-/analyze-existing /blog/declining-article
-/rewrite declining article
+/seomachine:analyze-existing /blog/declining-article
+/seomachine:rewrite declining article
 
 # Week 3: Meta improvements
 # Update meta elements for 5 low-CTR pages
 
 # Week 4: Trending topic
-/research [trending topic from report]
-/write [trending topic]
+/seomachine:research [trending topic from report]
+/seomachine:write [trending topic]
 
 # Month end: Review results, run new performance review
-/performance-review 30
+/seomachine:performance-review 30
 # Compare to previous month, adjust strategy
 ```
 

--- a/.claude/commands/seomachine/research.md
+++ b/.claude/commands/seomachine/research.md
@@ -3,7 +3,7 @@
 Use this command to conduct comprehensive SEO keyword research and competitive analysis before writing new content.
 
 ## Usage
-`/research [topic]`
+`/seomachine:research [topic]`
 
 ## What This Command Does
 1. Performs keyword research for your industry-related topics
@@ -123,7 +123,7 @@ Example: `research/brief-podcast-editing-software-2025-10-15.md`
 
 ## Next Steps
 The research brief serves as the foundation for:
-1. Running `/write [topic]` to create the optimized article
+1. Running `/seomachine:write [topic]` to create the optimized article
 2. Reference material for maintaining SEO focus throughout writing
 3. Checklist to ensure all competitive gaps are addressed
 

--- a/.claude/commands/seomachine/rewrite.md
+++ b/.claude/commands/seomachine/rewrite.md
@@ -3,7 +3,7 @@
 Use this command to update and improve existing your company blog posts based on analysis findings.
 
 ## Usage
-`/rewrite [topic or analysis file]`
+`/seomachine:rewrite [topic or analysis file]`
 
 ## What This Command Does
 1. Takes existing blog post content and improvement recommendations
@@ -16,7 +16,7 @@ Use this command to update and improve existing your company blog posts based on
 
 ### Pre-Rewrite Review
 - **Original Content**: Read the existing article thoroughly
-- **Analysis Report**: Review findings from `/analyze-existing` if available
+- **Analysis Report**: Review findings from `/seomachine:analyze-existing` if available
 - **Research Brief**: Check if new research brief exists for updated angles
 - **Brand Voice**: Verify alignment with current @context/brand-voice.md
 - **SEO Guidelines**: Apply latest requirements from @context/seo-guidelines.md
@@ -62,7 +62,7 @@ Based on analysis, classify the rewrite level:
 - Fluff or filler that doesn't add value
 
 ### Content Structure
-Follow same structure as `/write` command:
+Follow same structure as `/seomachine:write` command:
 
 #### 1. Updated Headline (H1)
 - Optimize with primary keyword if not already present
@@ -238,8 +238,8 @@ After saving the rewritten article, run optimization agents:
 After rewrite completion:
 1. Review change summary and ensure all updates are intentional
 2. Compare to original to verify improvements
-3. Run `/optimize` for final polish if needed
-4. Move to `/published` when ready
+3. Run `/seomachine:optimize` for final polish if needed
+4. Move to `published/` when ready
 5. Note original URL to ensure proper redirect/replacement
 
 This ensures every rewritten article is significantly improved while maintaining what worked in the original version.

--- a/.claude/commands/seomachine/scrub.md
+++ b/.claude/commands/seomachine/scrub.md
@@ -3,7 +3,7 @@
 Use this command to remove AI-generated content watermarks and telltale signs from markdown files.
 
 ## Usage
-`/scrub [file path]`
+`/seomachine:scrub [file path]`
 
 ## What This Command Does
 Removes invisible Unicode watermarks and replaces em-dashes with contextually appropriate punctuation to make content appear naturally human-written.
@@ -74,7 +74,7 @@ Sample of cleaned content:
 ## Example Usage
 
 ```
-/scrub drafts/content-marketing-guide-2025-10-31.md
+/seomachine:scrub drafts/content-marketing-guide-2025-10-31.md
 ```
 
 This will:
@@ -90,7 +90,7 @@ This will:
 - File will be overwritten with cleaned version (original is replaced)
 
 ## Best Practices
-- Run `/scrub` after generating content with `/write` or `/rewrite` (though this should happen automatically)
+- Run `/seomachine:scrub` after generating content with `/seomachine:write` or `/seomachine:rewrite` (though this should happen automatically)
 - Useful for cleaning files before publishing
 - Can be run on any markdown file in the workspace
 - Safe to run multiple times (idempotent - won't change already-clean content)
@@ -108,7 +108,7 @@ The goal is to make the content indistinguishable from naturally human-written t
 
 ## Integration Note
 
-This command is automatically triggered after `/write` and `/rewrite` commands, so you typically don't need to run it manually. Use this command when:
+This command is automatically triggered after `/seomachine:write` and `/seomachine:rewrite` commands, so you typically don't need to run it manually. Use this command when:
 - Testing the scrubber
 - Cleaning older content that wasn't auto-scrubbed
 - Verifying scrubbing was successful

--- a/.claude/commands/seomachine/write.md
+++ b/.claude/commands/seomachine/write.md
@@ -3,7 +3,7 @@
 Use this command to create comprehensive, SEO-optimized long-form blog content.
 
 ## Usage
-`/write [topic or research brief]`
+`/seomachine:write [topic or research brief]`
 
 ## What This Command Does
 1. Creates complete, well-structured long-form articles (2000-3000+ words)
@@ -15,7 +15,7 @@ Use this command to create comprehensive, SEO-optimized long-form blog content.
 ## Process
 
 ### Pre-Writing Review
-- **Research Brief**: Review research brief from `/research` command if available
+- **Research Brief**: Review research brief from `/seomachine:research` command if available
 - **Brand Voice**: Check @context/brand-voice.md for tone and messaging
 - **Writing Examples**: Study @context/writing-examples.md for style consistency
 - **Style Guide**: Follow formatting rules from @context/style-guide.md


### PR DESCRIPTION
## Summary
- Move all commands to `.claude/commands/seomachine/` subdirectory to properly namespace them
- Prevents potential conflicts with other Claude Code plugins that may define commands with the same names (like `/write`)
- Update all internal cross-references to use the new namespaced format

## Changes
Commands are now invoked as:
- `/seomachine:write` (was `/write`)
- `/seomachine:research` (was `/research`)
- `/seomachine:rewrite` (was `/rewrite`)
- `/seomachine:optimize` (was `/optimize`)
- `/seomachine:analyze-existing` (was `/analyze-existing`)
- `/seomachine:performance-review` (was `/performance-review`)
- `/seomachine:scrub` (was `/scrub`)

## Test plan
- [ ] Verify commands work with new namespace prefix
- [ ] Verify internal command references in documentation are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)