### PR TITLE
Fix bare except clause in check_ranking_history

### DIFF
--- a/data_sources/modules/dataforseo.py
+++ b/data_sources/modules/dataforseo.py
@@ -408,7 +408,7 @@ class DataForSEO:
                 task = response['tasks'][0]
                 if task['status_code'] == 20000:
                     return task['result'][0].get('items', [])
-        except:
+        except Exception:
             pass
 
         return []


### PR DESCRIPTION
Fixes issue with bare except clause in dataforseo.py check_ranking_history method.

Bare except clauses in Python catch all exceptions including system-level exceptions like SystemExit and KeyboardInterrupt, which should never be caught. This fix replaces the bare except with except Exception to properly handle only application-level exceptions while allowing system exceptions to propagate normally.