### PR TITLE
docs: clarify fork vs upstream clone in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ SEO Machine is built on Claude Code and provides:
 
 ### Installation
 
-1. Clone this repository:
+1. Fork this repository on GitHub, then clone your fork:
 ```bash
 git clone https://github.com/[your-username]/seomachine.git
 cd seomachine
+```
+
+Optionally, add the upstream repository as a remote to pull latest changes:
+```bash
+git remote add upstream https://github.com/TheCraigHewitt/seomachine.git
 ```
 
 2. Install Python dependencies for analysis modules:


### PR DESCRIPTION
## Summary
Clarify that users should fork the repository first before cloning, and add optional upstream remote setup for pulling latest changes.

## Changes
- Explicitly mention forking before cloning
- Add optional upstream remote configuration

## Testing
- Documentation renders correctly

Closes #18