### PR TITLE
Add feature: Docker support for easy setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.env
+credentials/
+drafts/
+output/
+published/
+research/
+rewrites/
+topics/
+__pycache__
+*.pyc
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Build/runtime deps needed by scientific and XML Python packages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    libxml2-dev \
+    libxslt1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY data_sources/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY . /app

--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -9,6 +9,13 @@ Get SEO Machine running in **10 minutes** ⚡
 pip install -r data_sources/requirements.txt
 ```
 
+### Docker Alternative
+
+```bash
+docker-compose build
+docker-compose run seomachine bash
+```
+
 ## Step 2: Configure Context Files (5 min)
 
 Fill out these **3 essential files** with your company info:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ claude-code .
 
    **Quick Start**: Check out `examples/castos/` to see a complete real-world example of all context files filled out for a podcast hosting SaaS company.
 
+## Docker Setup
+
+Before running Docker, configure `data_sources/config/.env` with your credentials.
+
+```bash
+docker-compose build
+docker-compose run seomachine bash
+```
+
+Content directories are mounted as volumes, so files in `topics/`, `research/`, `drafts/`, `published/`, `output/`, `rewrites/`, `context/`, and `credentials/` persist on your host.
+
 ## Workflows
 
 ### Creating New Content

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  seomachine:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - data_sources/config/.env
+    volumes:
+      - ./context:/app/context
+      - ./drafts:/app/drafts
+      - ./output:/app/output
+      - ./published:/app/published
+      - ./research:/app/research
+      - ./rewrites:/app/rewrites
+      - ./topics:/app/topics
+      - ./credentials:/app/credentials
+      - ./.claude:/app/.claude


### PR DESCRIPTION
## Summary

Adds Dockerfile, docker-compose.yml, and .dockerignore so users can run SEO Machine in a container without manually installing Python dependencies.

## Changes

- `Dockerfile` - Python 3.12-slim base, installs system deps (gcc, libxml2) and Python packages from `data_sources/requirements.txt`
- `docker-compose.yml` - Single `seomachine` service with env_file pointing to `data_sources/config/.env` and volume mounts for all content directories (context, drafts, output, published, research, rewrites, topics, credentials, .claude)
- `.dockerignore` - Excludes .git, credentials, user content dirs, and cache files from the build context
- `README.md` - Added Docker Setup section after existing setup instructions
- `QUICK-START.md` - Added Docker Alternative subsection in Step 1

## Usage

```bash
# Configure credentials first
cp .env.example data_sources/config/.env
# Edit data_sources/config/.env with your API keys

# Build and run
docker-compose build
docker-compose run seomachine bash
```

Content directories are mounted as volumes so all work persists on the host.

## Simulated Demo

![Docker setup demo](https://files.catbox.moe/m5qx8d.gif)

Fixes #19

This contribution was developed with AI assistance (Codex).