### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.env
+credentials/
+__pycache__
+*.pyc
+.claude/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt* ./
+RUN if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; else \
+    pip install --no-cache-dir \
+    requests \
+    python-dotenv \
+    google-analytics-data \
+    google-api-python-client \
+    google-auth \
+    beautifulsoup4 \
+    numpy \
+    scikit-learn \
+    textstat; fi
+
+# Copy project files
+COPY . .
+
+# Default command runs the research scripts
+CMD ["python3", "research_trending.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  seomachine:
+    build: .
+    volumes:
+      - ./.env:/app/.env:ro
+      - ./credentials:/app/credentials:ro
+      - ./research:/app/research
+      - ./drafts:/app/drafts
+      - ./output:/app/output
+      - ./published:/app/published
+    environment:
+      - PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
- Added `Dockerfile` based on Python 3.12-slim with all project dependencies
- Added `docker-compose.yml` with volume mounts for credentials, research output, drafts, and published content
- Added `.dockerignore` to exclude `.env`, `credentials/`, `.git`, and cache files from the build

### Usage
```bash
# Build and run
docker compose up --build

# Run a specific script
docker compose run seomachine python3 research_quick_wins.py
```

Fixes #19