### PR TITLE
docs: replace placeholder [your-username] URLs with actual repo URLs

### DIFF
--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -106,7 +106,7 @@ You now have:
 
 - Full Documentation: See README.md
 - Real Example: Check `examples/castos/` directory
-- Issues: https://github.com/[your-username]/seomachine/issues
+- Issues: https://github.com/TheCraigHewitt/seomachine/issues
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SEO Machine is built on Claude Code and provides:
 
 1. Clone this repository:
 ```bash
-git clone https://github.com/[your-username]/seomachine.git
+git clone https://github.com/TheCraigHewitt/seomachine.git
 cd seomachine
 ```
 


### PR DESCRIPTION
Closes #42

## Summary

Two documentation files contained unfilled template placeholder `[your-username]` that were never updated to the real repository owner.

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `README.md` | 26 | `github.com/[your-username]/seomachine.git` | `github.com/TheCraigHewitt/seomachine.git` |
| `QUICK-START.md` | 109 | `github.com/[your-username]/seomachine/issues` | `github.com/TheCraigHewitt/seomachine/issues` |

## Impact

The broken `git clone` URL was the **first command** in the Getting Started section, so new users would immediately hit a 404 error before even cloning the project.