### PR TITLE
fix: remove asyncio from requirements.txt — it is stdlib in Python 3.4+

### DIFF
--- a/data_sources/requirements.txt
+++ b/data_sources/requirements.txt
@@ -27,7 +27,6 @@ orjson>=3.9.0
 
 # Optional: For async API calls
 aiohttp>=3.9.0
-asyncio>=3.4.3
 
 # NLP and text analysis
 textstat>=0.7.3


### PR DESCRIPTION
Closes #44

## Problem

`data_sources/requirements.txt` lists `asyncio>=3.4.3` as a pip dependency:

```
# Optional: For async API calls
aiohttp>=3.9.0
asyncio>=3.4.3   ← this is wrong
```

`asyncio` has been part of the **Python standard library since Python 3.4** and cannot/should not be installed via pip. The PyPI `asyncio` package is an unmaintained stub targeting Python 2/3.3 only. Attempting to install it on Python 3.x fails:

```
ERROR: asyncio 3.4.3 requires Python==3.3.*
```

This breaks `pip install -r requirements.txt` for anyone using Python 3.4+.

## Fix

Remove the `asyncio>=3.4.3` line. The `asyncio` module is always available in Python 3.4+ with no installation required.

## References
- [Python docs: asyncio — stdlib since 3.4](https://docs.python.org/3/library/asyncio.html)
- [PyPI asyncio package note](https://pypi.org/project/asyncio/): "This package is not meant for Python 3 users"