### PR TITLE
fix: Harden DataForSEO empty-result handling

### DIFF
--- a/data_sources/modules/dataforseo.py
+++ b/data_sources/modules/dataforseo.py
@@ -10,6 +10,7 @@ import requests
 from typing import Dict, List, Optional, Any
 from datetime import datetime
 
+
 class DataForSEO:
     """DataForSEO API client"""
 
@@ -21,19 +22,19 @@ class DataForSEO:
             login: API login (defaults to env var)
             password: API password (defaults to env var)
         """
-        self.login = login or os.getenv('DATAFORSEO_LOGIN')
-        self.password = password or os.getenv('DATAFORSEO_PASSWORD')
-        self.base_url = os.getenv('DATAFORSEO_BASE_URL', 'https://api.dataforseo.com')
+        self.login = login or os.getenv("DATAFORSEO_LOGIN")
+        self.password = password or os.getenv("DATAFORSEO_PASSWORD")
+        self.base_url = os.getenv("DATAFORSEO_BASE_URL", "https://api.dataforseo.com")
 
         if not self.login or not self.password:
             raise ValueError("DATAFORSEO_LOGIN and DATAFORSEO_PASSWORD must be set")
 
         # Create auth header
         cred = f"{self.login}:{self.password}"
-        encoded_cred = base64.b64encode(cred.encode('ascii')).decode('ascii')
+        encoded_cred = base64.b64encode(cred.encode("ascii")).decode("ascii")
         self.headers = {
-            'Authorization': f'Basic {encoded_cred}',
-            'Content-Type': 'application/json'
+            "Authorization": f"Basic {encoded_cred}",
+            "Content-Type": "application/json",
         }
 
         self.session = requests.Session()
@@ -46,12 +47,28 @@ class DataForSEO:
         response.raise_for_status()
         return response.json()
 
+    def _first_task(self, response: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        tasks = response.get("tasks")
+        if isinstance(tasks, list) and tasks:
+            first = tasks[0]
+            if isinstance(first, dict):
+                return first
+        return None
+
+    def _first_result(self, task: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        result = task.get("result")
+        if isinstance(result, list) and result:
+            first = result[0]
+            if isinstance(first, dict):
+                return first
+        return None
+
     def get_rankings(
         self,
         domain: str,
         keywords: List[str],
         location_code: int = 2840,  # USA
-        language_code: str = "en"
+        language_code: str = "en",
     ) -> List[Dict[str, Any]]:
         """
         Get ranking positions for specific keywords
@@ -67,49 +84,57 @@ class DataForSEO:
         """
         tasks = []
         for keyword in keywords:
-            tasks.append({
-                "keyword": keyword,
-                "location_code": location_code,
-                "language_code": language_code,
-                "device": "desktop",
-                "os": "windows"
-            })
+            tasks.append(
+                {
+                    "keyword": keyword,
+                    "location_code": location_code,
+                    "language_code": language_code,
+                    "device": "desktop",
+                    "os": "windows",
+                }
+            )
 
-        response = self._post('/v3/serp/google/organic/live/advanced', tasks)
+        response = self._post("/v3/serp/google/organic/live/advanced", tasks)
 
         results = []
-        if response['status_code'] == 20000:
-            for task in response['tasks']:
-                if task['status_code'] == 20000:
-                    keyword = task['data']['keyword']
-                    items = task['result'][0].get('items', [])
+        if response["status_code"] == 20000:
+            for task in response.get("tasks", []):
+                if task.get("status_code") == 20000:
+                    keyword = task.get("data", {}).get("keyword")
+                    result = self._first_result(task)
+                    if not keyword or result is None:
+                        continue
+                    items = result.get("items", [])
 
                     # Find domain position
                     position = None
                     url = None
                     for i, item in enumerate(items, 1):
-                        if domain in item.get('domain', ''):
+                        if domain in item.get("domain", ""):
                             position = i
-                            url = item.get('url')
+                            url = item.get("url")
                             break
 
-                    results.append({
-                        'keyword': keyword,
-                        'domain': domain,
-                        'position': position,
-                        'url': url,
-                        'ranking': position is not None,
-                        'search_volume': task['result'][0].get('keyword_data', {}).get('keyword_info', {}).get('search_volume'),
-                        'cpc': task['result'][0].get('keyword_data', {}).get('keyword_info', {}).get('cpc')
-                    })
+                    results.append(
+                        {
+                            "keyword": keyword,
+                            "domain": domain,
+                            "position": position,
+                            "url": url,
+                            "ranking": position is not None,
+                            "search_volume": result.get("keyword_data", {})
+                            .get("keyword_info", {})
+                            .get("search_volume"),
+                            "cpc": result.get("keyword_data", {})
+                            .get("keyword_info", {})
+                            .get("cpc"),
+                        }
+                    )
 
         return results
 
     def get_serp_data(
-        self,
-        keyword: str,
-        location_code: int = 2840,
-        limit: int = 100
+        self, keyword: str, location_code: int = 2840, limit: int = 100
     ) -> Dict[str, Any]:
         """
         Get complete SERP data for a keyword
@@ -122,62 +147,68 @@ class DataForSEO:
         Returns:
             Dict with SERP data including all ranking pages
         """
-        data = [{
-            "keyword": keyword,
-            "location_code": location_code,
-            "language_code": "en",
-            "device": "desktop",
-            "os": "windows",
-            "depth": limit
-        }]
+        data = [
+            {
+                "keyword": keyword,
+                "location_code": location_code,
+                "language_code": "en",
+                "device": "desktop",
+                "os": "windows",
+                "depth": limit,
+            }
+        ]
 
-        response = self._post('/v3/serp/google/organic/live/advanced', data)
+        response = self._post("/v3/serp/google/organic/live/advanced", data)
 
-        if response['status_code'] != 20000:
-            return {'error': 'API request failed'}
+        if response["status_code"] != 20000:
+            return {"error": "API request failed"}
 
-        task = response['tasks'][0]
-        if task['status_code'] != 20000:
-            return {'error': 'Task failed'}
+        task = self._first_task(response)
+        if not task or task.get("status_code") != 20000:
+            return {"error": "Task failed"}
 
-        result = task['result'][0]
+        result = self._first_result(task)
+        if result is None:
+            return {"error": "Task returned no results"}
 
         # Extract organic results
         organic_results = []
-        for item in result.get('items', []):
-            if item['type'] == 'organic':
-                organic_results.append({
-                    'position': item.get('rank_absolute'),
-                    'url': item.get('url'),
-                    'domain': item.get('domain'),
-                    'title': item.get('title'),
-                    'description': item.get('description'),
-                    'breadcrumb': item.get('breadcrumb')
-                })
+        for item in result.get("items", []):
+            if item["type"] == "organic":
+                organic_results.append(
+                    {
+                        "position": item.get("rank_absolute"),
+                        "url": item.get("url"),
+                        "domain": item.get("domain"),
+                        "title": item.get("title"),
+                        "description": item.get("description"),
+                        "breadcrumb": item.get("breadcrumb"),
+                    }
+                )
 
         # Extract SERP features
         features = []
-        for item in result.get('items', []):
-            if item['type'] != 'organic':
-                features.append(item['type'])
+        for item in result.get("items", []):
+            if item["type"] != "organic":
+                features.append(item["type"])
 
-        keyword_data = result.get('keyword_data', {}).get('keyword_info', {})
+        keyword_data = result.get("keyword_data", {}).get("keyword_info", {})
 
         return {
-            'keyword': keyword,
-            'search_volume': keyword_data.get('search_volume'),
-            'cpc': keyword_data.get('cpc'),
-            'competition': keyword_data.get('competition'),
-            'organic_results': organic_results,
-            'features': list(set(features)),
-            'total_results': result.get('items_count', 0)
+            "keyword": keyword,
+            "search_volume": keyword_data.get("search_volume"),
+            "cpc": keyword_data.get("cpc"),
+            "competition": keyword_data.get("competition"),
+            "organic_results": organic_results,
+            "features": list(set(features)),
+            "total_results": result.get("items_count", 0),
         }
 
     def analyze_competitor(
         self,
         competitor_domain: str,
         keywords: List[str],
-        your_domain: Optional[str] = None
+        your_domain: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Analyze competitor rankings vs yours
@@ -192,26 +223,31 @@ class DataForSEO:
         """
         tasks = []
         for keyword in keywords:
-            tasks.append({
-                "keyword": keyword,
-                "location_code": 2840,
-                "language_code": "en",
-                "device": "desktop"
-            })
+            tasks.append(
+                {
+                    "keyword": keyword,
+                    "location_code": 2840,
+                    "language_code": "en",
+                    "device": "desktop",
+                }
+            )
 
-        response = self._post('/v3/serp/google/organic/live/advanced', tasks)
+        response = self._post("/v3/serp/google/organic/live/advanced", tasks)
 
         comparison = []
-        for i, task in enumerate(response['tasks']):
-            if task['status_code'] == 20000:
+        for i, task in enumerate(response.get("tasks", [])):
+            if task.get("status_code") == 20000:
                 keyword = keywords[i]
-                items = task['result'][0].get('items', [])
+                result = self._first_result(task)
+                if result is None:
+                    continue
+                items = result.get("items", [])
 
                 competitor_pos = None
                 your_pos = None
 
                 for j, item in enumerate(items, 1):
-                    domain = item.get('domain', '')
+                    domain = item.get("domain", "")
                     if competitor_domain in domain:
                         competitor_pos = j
                     if your_domain and your_domain in domain:
@@ -223,25 +259,28 @@ class DataForSEO:
                 elif competitor_pos and not your_pos:
                     gap = "Not ranking"
 
-                comparison.append({
-                    'keyword': keyword,
-                    'competitor_position': competitor_pos,
-                    'your_position': your_pos,
-                    'gap': gap,
-                    'opportunity': 'high' if competitor_pos and not your_pos else 'medium' if gap and gap > 10 else 'low'
-                })
+                comparison.append(
+                    {
+                        "keyword": keyword,
+                        "competitor_position": competitor_pos,
+                        "your_position": your_pos,
+                        "gap": gap,
+                        "opportunity": "high"
+                        if competitor_pos and not your_pos
+                        else "medium"
+                        if isinstance(gap, (int, float)) and gap > 10
+                        else "low",
+                    }
+                )
 
         return {
-            'competitor': competitor_domain,
-            'your_domain': your_domain,
-            'comparison': comparison
+            "competitor": competitor_domain,
+            "your_domain": your_domain,
+            "comparison": comparison,
         }
 
     def get_keyword_ideas(
-        self,
-        seed_keyword: str,
-        location_code: int = 2840,
-        limit: int = 100
+        self, seed_keyword: str, location_code: int = 2840, limit: int = 100
     ) -> List[Dict[str, Any]]:
         """
         Get related keyword ideas
@@ -254,43 +293,54 @@ class DataForSEO:
         Returns:
             List of related keywords with search volume, difficulty
         """
-        data = [{
-            "keyword": seed_keyword,
-            "location_code": location_code,
-            "language_code": "en",
-            "include_serp_info": True,
-            "limit": limit
-        }]
+        data = [
+            {
+                "keyword": seed_keyword,
+                "location_code": location_code,
+                "language_code": "en",
+                "include_serp_info": True,
+                "limit": limit,
+            }
+        ]
 
-        response = self._post('/v3/dataforseo_labs/google/related_keywords/live', data)
+        response = self._post("/v3/dataforseo_labs/google/related_keywords/live", data)
 
-        if response['status_code'] != 20000:
+        if response["status_code"] != 20000:
             return []
 
-        task = response['tasks'][0]
-        if task['status_code'] != 20000:
+        task = self._first_task(response)
+        if not task or task.get("status_code") != 20000:
+            return []
+
+        result = self._first_result(task)
+        if result is None:
             return []
 
         keywords = []
-        for item in task['result'][0].get('items', []):
-            keywords.append({
-                'keyword': item.get('keyword_data', {}).get('keyword'),
-                'search_volume': item.get('keyword_data', {}).get('keyword_info', {}).get('search_volume'),
-                'cpc': item.get('keyword_data', {}).get('keyword_info', {}).get('cpc'),
-                'competition': item.get('keyword_data', {}).get('keyword_info', {}).get('competition'),
-                'avg_position': item.get('serp_info', {}).get('se_results_count')
-            })
+        for item in result.get("items", []):
+            keywords.append(
+                {
+                    "keyword": item.get("keyword_data", {}).get("keyword"),
+                    "search_volume": item.get("keyword_data", {})
+                    .get("keyword_info", {})
+                    .get("search_volume"),
+                    "cpc": item.get("keyword_data", {})
+                    .get("keyword_info", {})
+                    .get("cpc"),
+                    "competition": item.get("keyword_data", {})
+                    .get("keyword_info", {})
+                    .get("competition"),
+                    "avg_position": item.get("serp_info", {}).get("se_results_count"),
+                }
+            )
 
         # Sort by search volume
-        keywords.sort(key=lambda x: x['search_volume'] or 0, reverse=True)
+        keywords.sort(key=lambda x: x["search_volume"] or 0, reverse=True)
 
         return keywords
 
     def get_questions(
-        self,
-        keyword: str,
-        location_code: int = 2840,
-        limit: int = 50
+        self, keyword: str, location_code: int = 2840, limit: int = 50
     ) -> List[Dict[str, Any]]:
         """
         Get question-based queries related to keyword
@@ -303,43 +353,67 @@ class DataForSEO:
         Returns:
             List of question queries
         """
-        data = [{
-            "keyword": keyword,
-            "location_code": location_code,
-            "language_code": "en",
-            "limit": limit
-        }]
+        data = [
+            {
+                "keyword": keyword,
+                "location_code": location_code,
+                "language_code": "en",
+                "limit": limit,
+            }
+        ]
 
-        response = self._post('/v3/dataforseo_labs/google/related_keywords/live', data)
+        response = self._post("/v3/dataforseo_labs/google/related_keywords/live", data)
 
-        if response['status_code'] != 20000:
+        if response["status_code"] != 20000:
             return []
 
-        task = response['tasks'][0]
-        if task['status_code'] != 20000:
+        task = self._first_task(response)
+        if not task or task.get("status_code") != 20000:
+            return []
+
+        result = self._first_result(task)
+        if result is None:
             return []
 
         questions = []
-        for item in task['result'][0].get('items', []):
-            kw = item.get('keyword_data', {}).get('keyword', '')
+        for item in result.get("items", []):
+            kw = item.get("keyword_data", {}).get("keyword", "")
 
             # Filter for questions
-            if any(kw.lower().startswith(q) for q in ['how', 'what', 'why', 'when', 'where', 'who', 'can', 'should', 'is', 'are', 'does']):
-                questions.append({
-                    'question': kw,
-                    'search_volume': item.get('keyword_data', {}).get('keyword_info', {}).get('search_volume'),
-                    'cpc': item.get('keyword_data', {}).get('keyword_info', {}).get('cpc')
-                })
+            if any(
+                kw.lower().startswith(q)
+                for q in [
+                    "how",
+                    "what",
+                    "why",
+                    "when",
+                    "where",
+                    "who",
+                    "can",
+                    "should",
+                    "is",
+                    "are",
+                    "does",
+                ]
+            ):
+                questions.append(
+                    {
+                        "question": kw,
+                        "search_volume": item.get("keyword_data", {})
+                        .get("keyword_info", {})
+                        .get("search_volume"),
+                        "cpc": item.get("keyword_data", {})
+                        .get("keyword_info", {})
+                        .get("cpc"),
+                    }
+                )
 
         # Sort by search volume
-        questions.sort(key=lambda x: x['search_volume'] or 0, reverse=True)
+        questions.sort(key=lambda x: x["search_volume"] or 0, reverse=True)
 
         return questions
 
-    def get_domain_metrics(
-        self,
-        domain: str
-    ) -> Dict[str, Any]:
+    def get_domain_metrics(self, domain: str) -> Dict[str, Any]:
         """
         Get domain overview metrics
 
@@ -349,36 +423,35 @@ class DataForSEO:
         Returns:
             Dict with domain metrics
         """
-        data = [{
-            "target": domain,
-            "location_code": 2840,
-            "language_code": "en"
-        }]
+        data = [{"target": domain, "location_code": 2840, "language_code": "en"}]
 
-        response = self._post('/v3/dataforseo_labs/google/domain_metrics/live', data)
+        response = self._post("/v3/dataforseo_labs/google/domain_metrics/live", data)
 
-        if response['status_code'] != 20000:
+        if response["status_code"] != 20000:
             return {}
 
-        task = response['tasks'][0]
-        if task['status_code'] != 20000:
+        task = self._first_task(response)
+        if not task or task.get("status_code") != 20000:
             return {}
 
-        metrics = task['result'][0].get('items', [{}])[0].get('metrics', {})
+        result = self._first_result(task)
+        if result is None:
+            return {}
+
+        items = result.get("items", [])
+        first_item = items[0] if items else {}
+        metrics = first_item.get("metrics", {}) if isinstance(first_item, dict) else {}
 
         return {
-            'domain': domain,
-            'organic_keywords': metrics.get('organic', {}).get('count'),
-            'organic_traffic': metrics.get('organic', {}).get('etv'),
-            'domain_rank': metrics.get('organic', {}).get('rank'),
-            'backlinks': metrics.get('backlinks', {})
+            "domain": domain,
+            "organic_keywords": metrics.get("organic", {}).get("count"),
+            "organic_traffic": metrics.get("organic", {}).get("etv"),
+            "domain_rank": metrics.get("organic", {}).get("rank"),
+            "backlinks": metrics.get("backlinks", {}),
         }
 
     def check_ranking_history(
-        self,
-        domain: str,
-        keyword: str,
-        months_back: int = 3
+        self, domain: str, keyword: str, months_back: int = 3
     ) -> List[Dict[str, Any]]:
         """
         Get ranking history for a keyword (requires historical data)
@@ -394,20 +467,24 @@ class DataForSEO:
         # Note: This requires DataForSEO's ranking tracking to be set up
         # This is a simplified version - actual implementation may vary
 
-        data = [{
-            "target": domain,
-            "keyword": keyword,
-            "location_code": 2840,
-            "language_code": "en"
-        }]
+        data = [
+            {
+                "target": domain,
+                "keyword": keyword,
+                "location_code": 2840,
+                "language_code": "en",
+            }
+        ]
 
         try:
-            response = self._post('/v3/serp/google/organic/ranking_history/live', data)
+            response = self._post("/v3/serp/google/organic/ranking_history/live", data)
 
-            if response['status_code'] == 20000:
-                task = response['tasks'][0]
-                if task['status_code'] == 20000:
-                    return task['result'][0].get('items', [])
+            if response["status_code"] == 20000:
+                task = self._first_task(response)
+                if task and task.get("status_code") == 20000:
+                    result = self._first_result(task)
+                    if result is not None:
+                        return result.get("items", [])
         except:
             pass
 
@@ -417,20 +494,25 @@ class DataForSEO:
 # Example usage
 if __name__ == "__main__":
     from dotenv import load_dotenv
-    load_dotenv('data_sources/config/.env')
+
+    load_dotenv("data_sources/config/.env")
 
     dfs = DataForSEO()
 
     print("Checking rankings for Castos...")
     rankings = dfs.get_rankings(
         domain="castos.com",
-        keywords=["podcast hosting", "podcast analytics", "private podcast"]
+        keywords=["podcast hosting", "podcast analytics", "private podcast"],
     )
 
     for rank in rankings:
         print(f"\nKeyword: {rank['keyword']}")
         print(f"Position: {rank['position'] or 'Not ranking'}")
-        print(f"Search Volume: {rank['search_volume']:,}" if rank['search_volume'] else "Search Volume: N/A")
+        print(
+            f"Search Volume: {rank['search_volume']:,}"
+            if rank["search_volume"]
+            else "Search Volume: N/A"
+        )
 
     print("\n\nGetting SERP data for 'podcast monetization'...")
     serp = dfs.get_serp_data("podcast monetization")
@@ -438,7 +520,7 @@ if __name__ == "__main__":
     print(f"Search Volume: {serp['search_volume']:,}")
     print(f"SERP Features: {', '.join(serp['features'])}")
     print(f"\nTop 10 Results:")
-    for result in serp['organic_results'][:10]:
+    for result in serp["organic_results"][:10]:
         print(f"{result['position']}. {result['domain']}")
         print(f"   {result['url']}")
 
@@ -446,4 +528,8 @@ if __name__ == "__main__":
     questions = dfs.get_questions("podcast monetization")
     for q in questions[:10]:
         print(f"- {q['question']}")
-        print(f"  Volume: {q['search_volume']:,}" if q['search_volume'] else "  Volume: N/A")
+        print(
+            f"  Volume: {q['search_volume']:,}"
+            if q["search_volume"]
+            else "  Volume: N/A"
+        )

--- a/tests/test_dataforseo_resilience.py
+++ b/tests/test_dataforseo_resilience.py
@@ -1,0 +1,65 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "data_sources" / "modules" / "dataforseo.py"
+)
+
+
+def load_dataforseo_module():
+    spec = importlib.util.spec_from_file_location("dataforseo_under_test", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DataForSEOResilienceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        module = load_dataforseo_module()
+        self.client = object.__new__(module.DataForSEO)
+
+    def test_get_serp_data_returns_task_error_when_result_is_missing(self):
+        self.client._post = lambda endpoint, data: {
+            "status_code": 20000,
+            "tasks": [{"status_code": 20000, "result": []}],
+        }
+
+        result = self.client.get_serp_data("test keyword")
+
+        self.assertEqual(result, {"error": "Task returned no results"})
+
+    def test_get_keyword_ideas_returns_empty_list_when_result_is_missing(self):
+        self.client._post = lambda endpoint, data: {
+            "status_code": 20000,
+            "tasks": [{"status_code": 20000, "result": []}],
+        }
+
+        result = self.client.get_keyword_ideas("seed keyword")
+
+        self.assertEqual(result, [])
+
+    def test_analyze_competitor_handles_missing_result_without_crashing(self):
+        self.client._post = lambda endpoint, data: {
+            "status_code": 20000,
+            "tasks": [
+                {
+                    "status_code": 20000,
+                    "data": {"keyword": "keyword one"},
+                    "result": [],
+                }
+            ],
+        }
+
+        result = self.client.analyze_competitor(
+            "competitor.com", ["keyword one"], your_domain="example.com"
+        )
+
+        self.assertEqual(result["comparison"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- guard DataForSEO task/result parsing so empty or missing result payloads no longer crash SERP and ranking fetches
- return a clear task-level error when the API accepts a request but returns no results
- add regression coverage for empty task/result payloads and partial keyword responses

## Testing
- python3 -m unittest tests.test_dataforseo_resilience