### PR TITLE
fix: handle missing gap difficulty in report

### DIFF
--- a/research_competitor_gaps.py
+++ b/research_competitor_gaps.py
@@ -455,10 +455,18 @@ def write_markdown_report(gaps: List[Dict[str, Any]], total_found: int):
 
         # Analyze patterns
         total_volume = sum(g.get('search_volume', 0) for g in gaps if g.get('search_volume'))
-        avg_difficulty = sum(g.get('difficulty', 0) for g in gaps if g.get('difficulty')) / len([g for g in gaps if g.get('difficulty')])
+        difficulty_values = [
+            g['difficulty']
+            for g in gaps
+            if isinstance(g.get('difficulty'), (int, float))
+        ]
 
         f.write(f"- **Total Potential Search Volume:** {total_volume:,}/month\n")
-        f.write(f"- **Average SEO Difficulty:** {avg_difficulty:.1f}/100\n")
+        if difficulty_values:
+            avg_difficulty = sum(difficulty_values) / len(difficulty_values)
+            f.write(f"- **Average SEO Difficulty:** {avg_difficulty:.1f}/100\n")
+        else:
+            f.write("- **Average SEO Difficulty:** N/A\n")
 
         # Content type breakdown
         content_types = {}

--- a/tests/test_research_competitor_gaps_report.py
+++ b/tests/test_research_competitor_gaps_report.py
@@ -1,0 +1,154 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "research_competitor_gaps.py"
+
+
+def load_research_competitor_gaps_module():
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+
+    modules_pkg = types.ModuleType("modules")
+    google_search_console = types.ModuleType("modules.google_search_console")
+    google_search_console.GoogleSearchConsole = object
+    dataforseo = types.ModuleType("modules.dataforseo")
+    dataforseo.DataForSEO = object
+    opportunity_scorer = types.ModuleType("modules.opportunity_scorer")
+    opportunity_scorer.OpportunityScorer = object
+    opportunity_scorer.OpportunityType = object
+    search_intent = types.ModuleType("modules.search_intent_analyzer")
+    search_intent.SearchIntentAnalyzer = object
+
+    injected = {
+        "dotenv": fake_dotenv,
+        "modules": modules_pkg,
+        "modules.google_search_console": google_search_console,
+        "modules.dataforseo": dataforseo,
+        "modules.opportunity_scorer": opportunity_scorer,
+        "modules.search_intent_analyzer": search_intent,
+    }
+    previous = {name: sys.modules.get(name) for name in injected}
+    sys.modules.update(injected)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "research_competitor_gaps_under_test", MODULE_PATH
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Unable to load {MODULE_PATH}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+class CompetitorGapsReportTests(unittest.TestCase):
+    def test_write_markdown_report_handles_missing_difficulty_values(self):
+        module = load_research_competitor_gaps_module()
+        gaps = [
+            {
+                "keyword": "podcast analytics",
+                "priority": "HIGH",
+                "opportunity_score": 88.0,
+                "competitor": "example.com",
+                "competitor_type": "Content",
+                "competitor_position": 4,
+                "search_volume": 1200,
+                "your_position": None,
+                "search_intent": "informational",
+                "content_type": "Guide/Article",
+                "score_breakdown": {
+                    "volume_score": 90,
+                    "competition_score": 75,
+                    "intent_score": 80,
+                },
+            },
+            {
+                "keyword": "podcast monetization",
+                "priority": "MEDIUM",
+                "opportunity_score": 65.0,
+                "competitor": "competitor.com",
+                "competitor_type": "Direct",
+                "competitor_position": 8,
+                "search_volume": 300,
+                "difficulty": None,
+                "your_position": None,
+                "search_intent": "commercial",
+                "content_type": "How-To Guide",
+            },
+        ]
+
+        old_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                os.chdir(tmpdir)
+                Path("research").mkdir()
+
+                module.write_markdown_report(gaps, total_found=2)
+
+                [report] = Path("research").glob("competitor-gaps-*.md")
+                content = report.read_text()
+                self.assertIn("- **Average SEO Difficulty:** N/A", content)
+                self.assertIn("- **Total Potential Search Volume:** 1,500/month", content)
+            finally:
+                os.chdir(old_cwd)
+
+    def test_write_markdown_report_averages_zero_difficulty_values(self):
+        module = load_research_competitor_gaps_module()
+        gaps = [
+            {
+                "keyword": "easy podcast seo",
+                "priority": "CRITICAL",
+                "opportunity_score": 91.0,
+                "competitor": "example.com",
+                "competitor_type": "Content",
+                "competitor_position": 2,
+                "search_volume": 100,
+                "difficulty": 0,
+                "your_position": None,
+                "search_intent": "informational",
+                "content_type": "Guide/Article",
+            },
+            {
+                "keyword": "hard podcast seo",
+                "priority": "HIGH",
+                "opportunity_score": 82.0,
+                "competitor": "example.org",
+                "competitor_type": "Content",
+                "competitor_position": 5,
+                "search_volume": 100,
+                "difficulty": 50,
+                "your_position": None,
+                "search_intent": "informational",
+                "content_type": "Guide/Article",
+            },
+        ]
+
+        old_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                os.chdir(tmpdir)
+                Path("research").mkdir()
+
+                module.write_markdown_report(gaps, total_found=2)
+
+                [report] = Path("research").glob("competitor-gaps-*.md")
+                self.assertIn(
+                    "- **Average SEO Difficulty:** 25.0/100", report.read_text()
+                )
+            finally:
+                os.chdir(old_cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Prevent `write_markdown_report()` from dividing by zero when no gap has a numeric `difficulty` value.
- Report average SEO difficulty as `N/A` when difficulty data is unavailable instead of crashing or implying `0.0/100`.
- Keep `0` as a valid numeric difficulty and include it in the average when present.
- Add regression coverage for both missing difficulty and zero-valued difficulty.

Fixes #40.

## Validation

- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile research_competitor_gaps.py tests/test_research_competitor_gaps_report.py`
- `git diff --check`

Note: the unittest run prints the existing `config/competitors.json not found` import warning from `research_competitor_gaps.py`, but all 10 tests pass.
