### PR TITLE
docs: clarify Claude Code subscription authentication

### DIFF
--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -4,6 +4,11 @@ Get SEO Machine running in **10 minutes** ⚡
 
 ## Step 1: Install Dependencies (2 min)
 
+Before starting, install [Claude Code](https://claude.com/claude-code) and
+authenticate with either a Claude Pro, Max, Team, or Enterprise subscription,
+or an Anthropic Console account with API billing enabled. Optional data-source
+integrations require their own credentials.
+
 ```bash
 # Install Python dependencies for analysis modules
 pip install -r data_sources/requirements.txt
@@ -45,7 +50,7 @@ Fill out these **3 essential files** with your company info:
 
 ```bash
 # Open in Claude Code
-claude-code .
+claude
 
 # Research a topic
 /research [your topic]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ SEO Machine is built on Claude Code and provides:
 
 ### Prerequisites
 - [Claude Code](https://claude.com/claude-code) installed
-- Anthropic API account
+- One of the following authentication options for Claude Code:
+  - A Claude Pro, Max, Team, or Enterprise subscription
+  - An Anthropic Console account with API billing enabled
+
+> Claude subscriptions and Anthropic Console API billing are separate. Optional
+> integrations such as DataForSEO, Google Analytics, and Google Search Console
+> require their own credentials.
 
 ### Installation
 
@@ -44,7 +50,7 @@ This installs:
 
 3. Open in Claude Code:
 ```bash
-claude-code .
+claude
 ```
 
 4. **Customize Context Files** (Important!):


### PR DESCRIPTION
## Summary

- document Claude subscription authentication for Pro, Max, Team, and Enterprise plans
- retain Anthropic Console API billing as an alternative
- update the Claude Code launch command from `claude-code .` to `claude`
- clarify that optional data-source integrations require separate credentials

## Verification

- ran `git diff --check`
- checked both `README.md` and `QUICK-START.md` for the outdated command and prerequisite
- verified the authentication options against the [Claude Code authentication documentation](https://docs.anthropic.com/en/docs/claude-code/iam)

Documentation-only change; no runtime behavior is modified.